### PR TITLE
Normalise concept

### DIFF
--- a/encog-core/data_util.c
+++ b/encog-core/data_util.c
@@ -1,0 +1,94 @@
+/*
+ * Encog(tm) Core v0.5 - ANSI C Version
+ * http://www.heatonresearch.com/encog/
+ * http://code.google.com/p/encog-java/
+
+ * Copyright 2008-2012 Heaton Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information on Heaton Research copyrights, licenses
+ * and trademarks visit:
+ * http://www.heatonresearch.com/copyright
+ */
+#include "encog.h"
+
+static const char *HEADER = "ENCOG-00";
+
+REAL EncogDataVariancePerIndex(const ENCOG_DATA *data,const int index,const REAL mean)
+{	
+	unsigned long i;
+    REAL variance = 0.0;
+	for (i = 0; i < data->recordCount; i++)
+    {
+        const REAL delta = (data->data[i*(data->inputCount+data->idealCount)+index] - mean);
+        variance += (delta * delta - variance) / (i + 1);
+    }
+	return variance;
+}
+REAL EncogDataStdevPerIndex(const ENCOG_DATA *data,const int index,const REAL mean)
+{	
+    return sqrt (EncogDataVariancePerIndex(data,index,mean) * ((REAL)data->recordCount / (REAL)(data->recordCount - 1)));
+}
+REAL EncogDataMeanPerIndex(const ENCOG_DATA *data,const int index)
+{
+	unsigned long i;
+    REAL mean = 0.0;
+    for (i = 0;i<data->recordCount;i++)
+    {
+        mean += (data->data[i*(data->inputCount+data->idealCount)+index] - mean) / (i + 1);
+    }
+    return mean;
+}
+ENCOG_DATA_NORM *EncogDataNormalise(ENCOG_DATA *data){
+	int i;
+	unsigned long j;
+	int data_count=data->inputCount+data->idealCount;
+
+	ENCOG_DATA_NORM *normalise_params=(ENCOG_DATA_NORM*)EncogUtilAlloc(data_count,sizeof(ENCOG_DATA_NORM));
+
+	for(i=0; i<data_count; i++)
+    {
+		const REAL mean = EncogDataMeanPerIndex(data,i);
+		const REAL stdev = EncogDataStdevPerIndex(data,i,mean);
+
+		normalise_params[i].mean=mean;
+		normalise_params[i].stdev=stdev;
+
+        for(j=0; j<data->recordCount; j++)
+        {
+			unsigned long index=j*data_count+i;
+			data->data[index]= (data->data[index]-mean)/stdev;
+		}
+	}
+
+	return normalise_params;
+}
+void EncogDataDenormalise(ENCOG_DATA *data,ENCOG_DATA_NORM *normalise_params)
+{
+	int i;
+	unsigned long j;
+    int data_count=data->inputCount+data->idealCount;
+
+	for(i=0; i<data_count; i++)
+    {
+		const REAL mean = normalise_params[i].mean;
+		const REAL stdev = normalise_params[i].stdev;
+
+        for(j=0; j<data->recordCount; j++)
+        {
+			unsigned long index=j*data_count+i;
+			data->data[index]= (data->data[index]*stdev)+mean;
+		}
+	}
+}

--- a/encog-core/encog-core.vcxproj
+++ b/encog-core/encog-core.vcxproj
@@ -137,6 +137,7 @@
   <ItemGroup>
     <ClCompile Include="activation.c" />
     <ClCompile Include="data.c" />
+    <ClCompile Include="data_util.c" />
     <ClCompile Include="encog.c" />
     <ClCompile Include="errorcalc.c" />
     <ClCompile Include="errors.c" />

--- a/encog-core/encog.h
+++ b/encog-core/encog.h
@@ -35,7 +35,7 @@ extern "C" {
 #include <time.h>
 #include <string.h>
 #include <ctype.h>
-#include <omp.h>
+//#include <omp.h>
 #include <assert.h>
 #ifdef _MSC_VER
 #include <conio.h>
@@ -202,6 +202,12 @@ typedef struct ENCOG_DATA
     REAL *cursor;
     REAL *data;
 } ENCOG_DATA;
+
+typedef struct ENCOG_DATA_NORM
+{
+	REAL stdev;
+	REAL mean;
+} ENCOG_DATA_NORM;
 
 typedef struct ENCOG_TRAINING_REPORT {
 	float error;
@@ -373,6 +379,9 @@ REAL *EncogDataGetIdeal(ENCOG_DATA *data, INT index);
 ENCOG_DATA *EncogDataGenerateRandom(INT inputCount, INT idealCount, INT records, REAL low, REAL high);
 ENCOG_DATA *EncogDataEGBLoad(char *f);
 void EncogDataEGBSave(char *egbFile,ENCOG_DATA *data);
+
+ENCOG_DATA_NORM *EncogDataNormalise(ENCOG_DATA *data);
+void EncogDataDenormalise(ENCOG_DATA *data,ENCOG_DATA_NORM *normalise_params);
 
 void EncogVectorAdd(REAL *v1, REAL *v2, int length);
 void EncogVectorSub(REAL* v1, REAL* v2, int length);


### PR DESCRIPTION
I think we should store the normalising parameters in the network?

Try using:

void print_data(ENCOG_DATA *data){

```
REAL *input,*ideal;
unsigned long i;
INT j;

for(i=0; i<data->recordCount; i++)
{
    printf("\nRecord %d",i);
    input = EncogDataGetInput(data,i);
    ideal = EncogDataGetIdeal(data,i);

    printf("\nInput: ");
    for(j=0; j<data->inputCount; j++){
        printf("%0.3f ",input[j]);
    }

    printf("\nIdeal: ");
    for(j=0; j<data->idealCount; j++){
        printf("%0.3f ",ideal[j]);
    }
}
```

}

int main()
{
    ENCOG_DATA *data;
    ENCOG_DATA_NORM *norm;

```
data = EncogDataGenerateRandom(5,2,10,0,10);

printf("\n--------------------------\n");
print_data(data);
printf("\n--------------------------\n");

norm=EncogDataNormalise(data);

printf("\n------------NORMAL--------------\n");
print_data(data);
printf("\n--------------------------\n");

EncogDataDenormalise(data,norm);

printf("\n------------DE-NORMAL--------------\n");
print_data(data);
printf("\n--------------------------\n");

return 0;
```

}

Signed-off-by: Stephen Cox stephencoxmail@gmail.com
