### PR TITLE
Fixed MemcpyToSymbol call for CUDA 5.0+

### DIFF
--- a/encog-core/cuda_eval.cu
+++ b/encog-core/cuda_eval.cu
@@ -235,7 +235,7 @@ extern "C" GPU_DEVICE *EncogGPUDeviceNew(INT deviceNumber, ENCOG_NEURAL_NETWORK 
 		}
 	}
 
-	cudaMemcpyToSymbol("cnet", &tempConstNet, sizeof(GPU_CONST_NETWORK));
+	cudaMemcpyToSymbol(cnet, &tempConstNet, sizeof(GPU_CONST_NETWORK));
 
 	result = (GPU_DEVICE*)EncogUtilAlloc(1,sizeof(GPU_DEVICE));
 


### PR DESCRIPTION
encog_core/cuda_eval.cu contains syntax that was deprecated in CUDA 4.0 and removed in CUDA 5.0.
